### PR TITLE
[feature] add options to pass transforms and externals to browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ The simplest way to run testling type tests in the browser. Supports babelified 
     run-browser-babel <file> <options>
 
     Options:
-      -p --port <number>               The port number to run the server on (default: 3000)
-      -b --phantom                     Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)
-      -r --report                      Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)
-      -t --timeout                     Global timeout in milliseconds for tests to finish. (default: Infinity)
-      -bp --browserify-plugin <module> Register <module> as a browserify plugin
+      -p --port <number>                      The port number to run the server on (default: 3000)
+      -b --phantom                            Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)
+      -r --report                             Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)
+      -t --timeout                            Global timeout in milliseconds for tests to finish. (default: Infinity)
+
+    Browserify Options:
+      --bp --browserify-plugin <module>       Register <module> as a browserify plugin
+      --bt --browserify-transform <transform> Use a transform module on top-level files
+      --bx --browserify-external <module>     Reference a file from another bundle. Files can be globs
 
     Example:
       run-browser-babel test-file.js --port 3030 --report text --report html --report=cobertura --browserify-plugin proxyquireify/plugin

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,7 +17,10 @@ var phantom = args.b || args.phantom || args.phantomjs;
 var report = args.p || args.report || args.istanbul;
 var debug = args.d || args.debug;
 var timeout = args.t || args.timeout || Infinity;
+
 var browserifyOpts = {
+  externals: [].concat(args.bx).concat(args['browserify-external']).filter(Boolean),
+  transforms: [].concat(args.bt).concat(args['browserify-transform']).filter(Boolean),
   plugins: [].concat(args.bp).concat(args['browserify-plugin']).filter(Boolean)
 };
 
@@ -28,11 +31,15 @@ if (help) {
     '  run-browser-babel <file> <options>',
     '',
     'Options:',
-    '  -p --port <number>               The port number to run the server on (default: 3000)',
-    '  -b --phantom                     Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)',
-    '  -r --report                      Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)',
-    '  -t --timeout                     Global timeout in milliseconds for tests to finish. (default: Infinity)',
-    '  -bp --browserify-plugin <module> Register <module> as a browserify plugin',
+    '  -p --port <number>                      The port number to run the server on (default: 3000)',
+    '  -b --phantom                            Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)',
+    '  -r --report                             Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)',
+    '  -t --timeout                            Global timeout in milliseconds for tests to finish. (default: Infinity)',
+    '',
+    'Browserify Options:',
+    '  --bp --browserify-plugin <module>       Register <module> as a browserify plugin',
+    '  --bt --browserify-transform <transform> Use a transform module on top-level files',
+    '  --bx --browserify-external <module>     Reference a file from another bundle. Files can be globs',
     '',
     'Example:',
     '  run-browser-babel test-file.js --port 3030 --report text --report html --report=cobertura --browserify-plugin proxyquireify/plugin',


### PR DESCRIPTION
The first is useful and better than using the `package.json` `browserify.transforms` field since it would allow for applying transforms in dev vs prod (such as using the [bulkify](https://github.com/substack/bulkify) transform to require all `.js` files in the test directory).

The second is necessary if you want to use [enzyme](https://github.com/airbnb/enzyme/blob/master/docs/guides/browserify.md) to unit test react components.

:memo: updated docs to mention new options.

:bug: shorthand `-bp` browserify option did not work, needed to be `--bp`.
